### PR TITLE
refactor(config): centraliza gerenciamento de configurações com .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Este é um arquivo de exemplo para as variáveis de ambiente do projeto.
+#
+# Para configurar o ambiente de desenvolvimento, copie este arquivo para .env
+# Para configurar o ambiente de testes, copie este arquivo para .env.test
+#
+# Preencha cada arquivo com os valores apropriados para o seu respectivo ambiente.
+
+# URL de conexão com o banco de dados SQLAlchemy.
+#
+# Exemplo para desenvolvimento (.env):
+# DATABASE_URL="sqlite:///src/kanban/kanban.db"
+#
+# Exemplo para testes (.env.test):
+# DATABASE_URL="sqlite:///tests/test.db"
+
+DATABASE_URL=

--- a/src/kanban/config.py
+++ b/src/kanban/config.py
@@ -1,0 +1,29 @@
+"""
+Módulo de Configuração Centralizado.
+
+Este arquivo define e carrega as configurações da aplicação a partir de
+variáveis de ambiente e do arquivo .env, utilizando Pydantic Settings
+para validação e tipagem.
+"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """
+    **Configurações da aplicação carregadas de variáveis de ambiente.**
+
+    Define as variáveis que a aplicação espera encontrar no ambiente ou
+    no arquivo .env.
+    """
+
+    # O valor padrão aqui serve como fallback caso a variável não seja definida no .env
+    DATABASE_URL: str = "sqlite:///./kanban.db"
+
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
+
+
+# Instância única que será usada em toda a aplicação
+settings = Settings()

--- a/src/kanban/database.py
+++ b/src/kanban/database.py
@@ -8,14 +8,12 @@ e a fábrica de sessões que a aplicação usará para interagir com o banco.
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-# URL de conexão para o banco de dados SQLite local.
-SQLALCHEMY_DATABASE_URL = "sqlite:///src/kanban/kanban.db"
+from kanban.config import settings
+
 
 # Engine do SQLAlchemy, que gerencia as conexões.
 # O argumento `connect_args` é necessário para o SQLite em ambientes multithread.
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
+engine = create_engine(settings.DATABASE_URL, connect_args={"check_same_thread": False})
 
 # Fábrica de sessões. Cada instância de `SessionLocal` será uma sessão com o banco.
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,20 +6,24 @@ do FastAPI para usar o banco de teste e garante o isolamento entre os testes.
 """
 
 import os
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from fastapi.testclient import TestClient
+
+from kanban.config import Settings
 from kanban.database import get_db, Base
 from kanban.main import app
 
-# Caminho fixo para o banco de dados de teste
-PATH_TESTE_DB = "tests/teste.db"
-SQLALCHEMY_DATABASE_URL = f"sqlite:///{PATH_TESTE_DB}"
+# Sobrescreve as configurações específicas para o banco de teste
+test_settings = Settings(
+    _env_file=".env.test", _env_file_encoding="utf-8", extra="ignore"
+)
 
 # Cria engine e sessão para o banco de teste
 engine_test = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    test_settings.DATABASE_URL, connect_args={"check_same_thread": False}
 )
 SessionLocalTest = sessionmaker(autocommit=False, autoflush=False, bind=engine_test)
 
@@ -64,5 +68,7 @@ def pytest_sessionfinish():
     Remove o arquivo do banco de teste ao final da sessão de testes.
     """
     engine_test.dispose()
-    if os.path.exists(PATH_TESTE_DB):
-        os.remove(PATH_TESTE_DB)
+
+    db_path = test_settings.DATABASE_URL.rsplit("///", 1)[-1]
+    if os.path.exists(db_path):
+        os.remove(db_path)


### PR DESCRIPTION
Esta alteração refatora o gerenciamento de configurações para utilizar `pydantic-settings`, desacoplando valores sensíveis e/ou específicos do ambiente do código-fonte.

- Criado o módulo `src/kanban/config.py` para carregar e validar as variáveis de ambiente de forma centralizada.
- A URL do banco de dados agora é lida de arquivos `.env` (desenvolvimento) e `.env.test` (testes).
- Adicionado o arquivo `.env.example` como um modelo para facilitar a configuração do projeto.
- Os módulos `database.py` e `tests/conftest.py` foram atualizados para consumir as configurações a partir deste novo ponto central.

Resolve: #3